### PR TITLE
build: add osx & win64 build with Github Actions

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,6 @@
 name: Build MacOS
 
-on: [push]
+on: push
 
 jobs:
   macos:
@@ -59,3 +59,11 @@ jobs:
         with:
           name: packages
           path: dmg
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/') && endsWith(github.ref, 'gm')
+        with:
+          files:
+            dmg/*.dmg
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/options.yml
+++ b/.github/workflows/options.yml
@@ -1,9 +1,6 @@
 name: CMake Options Test
 
-on:
-  push:
-  schedule:
-    - cron: '1 0 * * *'
+on: push
 
 jobs:
   options:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,6 +1,6 @@
 name: Build Ubuntu
 
-on: [push]
+on: push
 
 jobs:
   ubuntu:
@@ -44,3 +44,11 @@ jobs:
         with:
           name: packages
           path: deb
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/') && endsWith(github.ref, 'gm')
+        with:
+          files:
+            deb/*.deb
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,6 @@
 name: Build Windows
 
-on: [push]
+on: push
 
 jobs:
   windows:
@@ -69,3 +69,11 @@ jobs:
         with:
           name: packages
           path: exe
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/') && endsWith(github.ref, 'gm')
+        with:
+          files:
+            exe/*.exe
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/epan/dissectors/packet-tls-utils.c
+++ b/epan/dissectors/packet-tls-utils.c
@@ -371,6 +371,20 @@ static const value_string ssl_20_cipher_suites[] = {
     { 0x00CCAD, "TLS_DHE_PSK_WITH_CHACHA20_POLY1305_SHA256" },
     { 0x00CCAE, "TLS_RSA_PSK_WITH_CHACHA20_POLY1305_SHA256" },
 
+    /* GM/T 0024-2014 */
+    { 0x00e001, "ECDHE_SM1_SM3"},
+    { 0x00e003, "ECC_SM1_SM3"},
+    { 0x00e005, "IBSDH_SM1_SM3"},
+    { 0x00e007, "IBC_SM1_SM3"},
+    { 0x00e009, "RSA_SM1_SM3"},
+    { 0x00e00a, "RSA_SM1_SHA1"},
+    { 0x00e011, "ECDHE_SM4_SM3"},
+    { 0x00e013, "ECC_SM4_SM3"},
+    { 0x00e015, "IBSDH_SM4_SM3"},
+    { 0x00e017, "IBC_SM4_SM3"},
+    { 0x00e019, "RSA_SM4_SM3"},
+    { 0x00e01a, "RSA_SM4_SHA1"},
+
     /* https://tools.ietf.org/html/draft-josefsson-salsa20-tls */
     { 0x00E410, "TLS_RSA_WITH_ESTREAM_SALSA20_SHA1" },
     { 0x00E411, "TLS_RSA_WITH_SALSA20_SHA1" },
@@ -408,19 +422,7 @@ static const value_string ssl_20_cipher_suites[] = {
     { 0x060040, "SSL2_DES_64_CBC_WITH_MD5" },
     { 0x0700c0, "SSL2_DES_192_EDE3_CBC_WITH_MD5" },
     { 0x080080, "SSL2_RC4_64_WITH_MD5" },
-     /*GMTLS: GM/T 0024-2014*/
-    { 0x00e001, "ECDHE_SM1_SM3"},
-    { 0x00e003, "ECC_SM1_SM3"},
-    { 0x00e005, "IBSDH_SM1_SM3"},
-    { 0x00e007, "IBC_SM1_SM3"},
-    { 0x00e009, "RSA_SM1_SM3"},
-    { 0x00e00a, "RSA_SM1_SHA1"},
-    { 0x00e011, "ECDHE_SM4_SM3"},
-    { 0x00e013, "ECC_SM4_SM3"},
-    { 0x00e015, "IBSDH_SM4_SM3"},
-    { 0x00e017, "IBC_SM4_SM3"},
-    { 0x00e019, "RSA_SM4_SM3"},
-    { 0x00e01a, "RSA_SM4_SHA1"},
+
     { 0x00, NULL }
 };
 
@@ -1100,6 +1102,19 @@ static const value_string ssl_31_ciphersuite[] = {
     { 0xD005, "TLS_ECDHE_PSK_WITH_AES_128_CCM_SHA256" },
     /* RFC 8701 */
     { 0xDADA, "Reserved (GREASE)" },
+    /* GM/T 0024-2014 */
+    { 0xe001, "ECDHE_SM1_SM3"},
+    { 0xe003, "ECC_SM1_SM3"},
+    { 0xe005, "IBSDH_SM1_SM3"},
+    { 0xe007, "IBC_SM1_SM3"},
+    { 0xe009, "RSA_SM1_SM3"},
+    { 0xe00a, "RSA_SM1_SHA1"},
+    { 0xe011, "ECDHE_SM4_SM3"},
+    { 0xe013, "ECC_SM4_SM3"},
+    { 0xe015, "IBSDH_SM4_SM3"},
+    { 0xe017, "IBC_SM4_SM3"},
+    { 0xe019, "RSA_SM4_SM3"},
+    { 0xe01a, "RSA_SM4_SHA1"},
     /* https://tools.ietf.org/html/draft-josefsson-salsa20-tls */
     { 0xE410, "TLS_RSA_WITH_ESTREAM_SALSA20_SHA1" },
     { 0xE411, "TLS_RSA_WITH_SALSA20_SHA1" },
@@ -1126,21 +1141,6 @@ static const value_string ssl_31_ciphersuite[] = {
     { 0xfeff, "SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA" },
     { 0xffe0, "SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA" },
     { 0xffe1, "SSL_RSA_FIPS_WITH_DES_CBC_SHA" },
-
-     /*GMSSL: GM/T 0024-2014*/
-    { 0xe001, "ECDHE_SM1_SM3"},
-    { 0xe003, "ECC_SM1_SM3"},
-    { 0xe005, "IBSDH_SM1_SM3"},
-    { 0xe007, "IBC_SM1_SM3"},
-    { 0xe009, "RSA_SM1_SM3"},
-    { 0xe00a, "RSA_SM1_SHA1"},
-    { 0xe011, "ECDHE_SM4_SM3"},
-    { 0xe013, "ECC_SM4_SM3"},
-    { 0xe015, "IBSDH_SM4_SM3"},
-    { 0xe017, "IBC_SM4_SM3"},
-    { 0xe019, "RSA_SM4_SM3"},
-    { 0xe01a, "RSA_SM4_SHA1"},
-
     /* note that ciphersuites 0xff00 - 0xffff are private */
     { 0x00, NULL }
 };

--- a/epan/dissectors/packet-tls-utils.c
+++ b/epan/dissectors/packet-tls-utils.c
@@ -58,6 +58,7 @@ const value_string ssl_version_short_names[] = {
     { SSLV2_VERSION,        "SSLv2" },
     { SSLV3_VERSION,        "SSLv3" },
     { TLSV1_VERSION,        "TLSv1" },
+    { GMTLSV1_VERSION,      "GMTLSv1" },
     { TLSV1DOT1_VERSION,    "TLSv1.1" },
     { TLSV1DOT2_VERSION,    "TLSv1.2" },
     { TLSV1DOT3_VERSION,    "TLSv1.3" },
@@ -71,6 +72,7 @@ const value_string ssl_versions[] = {
     { SSLV2_VERSION,        "SSL 2.0" },
     { SSLV3_VERSION,        "SSL 3.0" },
     { TLSV1_VERSION,        "TLS 1.0" },
+    { GMTLSV1_VERSION,      "GMTLS" },
     { TLSV1DOT1_VERSION,    "TLS 1.1" },
     { TLSV1DOT2_VERSION,    "TLS 1.2" },
     { TLSV1DOT3_VERSION,    "TLS 1.3" },
@@ -406,7 +408,19 @@ static const value_string ssl_20_cipher_suites[] = {
     { 0x060040, "SSL2_DES_64_CBC_WITH_MD5" },
     { 0x0700c0, "SSL2_DES_192_EDE3_CBC_WITH_MD5" },
     { 0x080080, "SSL2_RC4_64_WITH_MD5" },
-
+     /*GMTLS: GM/T 0024-2014*/
+    { 0x00e001, "ECDHE_SM1_SM3"},
+    { 0x00e003, "ECC_SM1_SM3"},
+    { 0x00e005, "IBSDH_SM1_SM3"},
+    { 0x00e007, "IBC_SM1_SM3"},
+    { 0x00e009, "RSA_SM1_SM3"},
+    { 0x00e00a, "RSA_SM1_SHA1"},
+    { 0x00e011, "ECDHE_SM4_SM3"},
+    { 0x00e013, "ECC_SM4_SM3"},
+    { 0x00e015, "IBSDH_SM4_SM3"},
+    { 0x00e017, "IBC_SM4_SM3"},
+    { 0x00e019, "RSA_SM4_SM3"},
+    { 0x00e01a, "RSA_SM4_SHA1"},
     { 0x00, NULL }
 };
 
@@ -632,6 +646,7 @@ const value_string ssl_31_client_certificate_type[] = {
     { 64, "ECDSA Sign" },
     { 65, "RSA Fixed ECDH" },
     { 66, "ECDSA Fixed ECDH" },
+    { 80, "IBC Params" },
     { 0x00, NULL }
 };
 
@@ -1111,6 +1126,21 @@ static const value_string ssl_31_ciphersuite[] = {
     { 0xfeff, "SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA" },
     { 0xffe0, "SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA" },
     { 0xffe1, "SSL_RSA_FIPS_WITH_DES_CBC_SHA" },
+
+     /*GMSSL: GM/T 0024-2014*/
+    { 0xe001, "ECDHE_SM1_SM3"},
+    { 0xe003, "ECC_SM1_SM3"},
+    { 0xe005, "IBSDH_SM1_SM3"},
+    { 0xe007, "IBC_SM1_SM3"},
+    { 0xe009, "RSA_SM1_SM3"},
+    { 0xe00a, "RSA_SM1_SHA1"},
+    { 0xe011, "ECDHE_SM4_SM3"},
+    { 0xe013, "ECC_SM4_SM3"},
+    { 0xe015, "IBSDH_SM4_SM3"},
+    { 0xe017, "IBC_SM4_SM3"},
+    { 0xe019, "RSA_SM4_SM3"},
+    { 0xe01a, "RSA_SM4_SHA1"},
+
     /* note that ciphersuites 0xff00 - 0xffff are private */
     { 0x00, NULL }
 };
@@ -1225,6 +1255,7 @@ const value_string tls_hash_algorithm[] = {
     { 4, "SHA256" },
     { 5, "SHA384" },
     { 6, "SHA512" },
+    { 7, "SM3" },
     { 0, NULL }
 };
 
@@ -1233,6 +1264,7 @@ const value_string tls_signature_algorithm[] = {
     { 1, "RSA" },
     { 2, "DSA" },
     { 3, "ECDSA" },
+    { 4, "SM2" },
     { 0, NULL }
 };
 
@@ -2988,6 +3020,19 @@ static const SslCipherSuite cipher_suites[]={
     {0xCCAC,KEX_ECDHE_PSK,      ENC_CHACHA20,   DIG_SHA256, MODE_POLY1305 }, /* TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256 */
     {0xCCAD,KEX_DHE_PSK,        ENC_CHACHA20,   DIG_SHA256, MODE_POLY1305 }, /* TLS_DHE_PSK_WITH_CHACHA20_POLY1305_SHA256 */
     {0xCCAE,KEX_RSA_PSK,        ENC_CHACHA20,   DIG_SHA256, MODE_POLY1305 }, /* TLS_RSA_PSK_WITH_CHACHA20_POLY1305_SHA256 */
+    /* GM */
+    {0xe001,KEX_ECDHE_SM2,      ENC_SM1,        DIG_SM3,    MODE_CBC},        /* ECDHE_SM1_SM3 */
+    {0xe003,KEX_ECC_SM2,        ENC_SM1,        DIG_SM3,    MODE_CBC},        /* ECC_SM1_SM3 */
+    {0xe005,KEX_IBSDH_SM9,      ENC_SM1,        DIG_SM3,    MODE_CBC},        /* IBSDH_SM1_SM3 */
+    {0xe007,KEX_IBC_SM9,        ENC_SM1,        DIG_SM3,    MODE_CBC},        /* IBC_SM1_SM3 */
+    {0xe009,KEX_RSA,            ENC_SM1,        DIG_SM3,    MODE_CBC},        /* RSA_SM1_SM3 */
+    {0xe00a,KEX_RSA,            ENC_SM1,        DIG_SHA,    MODE_CBC},        /* RSA_SM1_SHA1 */
+    {0xe011,KEX_ECDHE_SM2,      ENC_SM4,        DIG_SM3,    MODE_CBC},        /* ECDHE_SM4_SM3 */
+    {0xe013,KEX_ECC_SM2,        ENC_SM4,        DIG_SM3,    MODE_CBC},        /* ECC_SM4_SM3 */
+    {0xe015,KEX_IBSDH_SM9,      ENC_SM4,        DIG_SM3,    MODE_CBC},        /* IBSDH_SM4_SM3 */
+    {0xe017,KEX_IBC_SM9,        ENC_SM4,        DIG_SM3,    MODE_CBC},        /* IBC_SM4_SM3 */
+    {0xe019,KEX_RSA,            ENC_SM4,        DIG_SM3,    MODE_CBC},        /* RSA_SM4_SM3 */
+    {0xe01a,KEX_RSA,            ENC_SM4,        DIG_SHA,    MODE_CBC},        /* RSA_SM4_SHA1 */
     {-1,    0,                  0,              0,          MODE_STREAM}
 };
 
@@ -3303,6 +3348,7 @@ prf(SslDecryptSession *ssl, StringInfo *secret, const gchar *usage,
     case TLSV1DOT1_VERSION:
     case DTLSV1DOT0_VERSION:
     case DTLSV1DOT0_OPENSSL_VERSION:
+    case GMTLSV1_VERSION:
         return tls_prf(secret, usage, rnd1, rnd2, out, out_len);
 
     default: /* TLSv1.2 */
@@ -3787,7 +3833,8 @@ ssl_generate_pre_master_secret(SslDecryptSession *ssl_session,
             ssl_session->session.version == TLSV1DOT1_VERSION ||
             ssl_session->session.version == TLSV1DOT2_VERSION ||
             ssl_session->session.version == DTLSV1DOT0_VERSION ||
-            ssl_session->session.version == DTLSV1DOT2_VERSION))
+            ssl_session->session.version == DTLSV1DOT2_VERSION ||
+            ssl_session->session.version == GMTLSV1_VERSION ))
         {
             encrlen  = tvb_get_ntohs(tvb, offset);
             skip = 2;
@@ -3891,6 +3938,7 @@ ssl_generate_keyring_material(SslDecryptSession*ssl_session)
             case TLSV1DOT1_VERSION:
             case DTLSV1DOT0_VERSION:
             case DTLSV1DOT0_OPENSSL_VERSION:
+            case GMTLSV1_VERSION:
                 ret = tls_handshake_hash(ssl_session, &handshake_hashed_data);
                 break;
             default:
@@ -4894,7 +4942,7 @@ ssl_decrypt_record(SslDecryptSession *ssl, SslDecoder *decoder, guint8 ct, guint
             ssl_debug_printf("ssl_decrypt_record: mac ok\n");
         }
     }
-    else if(ssl->session.version==TLSV1_VERSION || ssl->session.version==TLSV1DOT1_VERSION || ssl->session.version==TLSV1DOT2_VERSION){
+    else if(ssl->session.version==TLSV1_VERSION || ssl->session.version==TLSV1DOT1_VERSION || ssl->session.version==TLSV1DOT2_VERSION || ssl->session.version==GMTLSV1_VERSION){
         if(tls_check_mac(decoder,ct,ssl->session.version,mac_frag,mac_fraglen,mac)< 0) {
             if(ignore_mac_failed) {
                 ssl_debug_printf("ssl_decrypt_record: mac failed, but ignored for troubleshooting ;-)\n");
@@ -8270,6 +8318,7 @@ ssl_try_set_version(SslSession *session, SslDecryptSession *ssl,
     case TLSV1DOT1_VERSION:
     case TLSV1DOT2_VERSION:
     case TLSV1DOT3_VERSION:
+    case GMTLSV1_VERSION:
         if (is_dtls)
             return;
         break;

--- a/epan/dissectors/packet-tls-utils.h
+++ b/epan/dissectors/packet-tls-utils.h
@@ -240,6 +240,7 @@ typedef struct _StringInfo {
                                           http://www-archive.mozilla.org/projects/security/pki/nss/ssl/draft02.html */
 #define SSLV3_VERSION          0x300
 #define TLSV1_VERSION          0x301
+#define GMTLSV1_VERSION        0x101
 #define TLSV1DOT1_VERSION      0x302
 #define TLSV1DOT2_VERSION      0x303
 #define TLSV1DOT3_VERSION      0x304
@@ -363,7 +364,14 @@ typedef struct {
 #define KEX_TLS13       0x23
 #define KEX_ECJPAKE     0x24
 
+#define KEX_ECDHE_SM2   0x25
+#define KEX_ECC_SM2     0x26
+#define KEX_IBSDH_SM9   0x27
+#define KEX_IBC_SM9     0x28
+
 /* Order is significant, must match "ciphers" array in packet-tls-utils.c */
+
+#define ENC_START       0x30
 #define ENC_DES         0x30
 #define ENC_3DES        0x31
 #define ENC_RC4         0x32
@@ -376,12 +384,16 @@ typedef struct {
 #define ENC_SEED        0x39
 #define ENC_CHACHA20    0x3A
 #define ENC_NULL        0x3B
+#define ENC_SM1         0x3C
+#define ENC_SM4         0x3D
+
 
 #define DIG_MD5         0x40
 #define DIG_SHA         0x41
 #define DIG_SHA256      0x42
 #define DIG_SHA384      0x43
 #define DIG_NA          0x44 /* Not Applicable */
+#define DIG_SM3         0x45
 
 typedef struct {
     const gchar *name;

--- a/epan/dissectors/packet-tls.c
+++ b/epan/dissectors/packet-tls.c
@@ -714,6 +714,7 @@ dissect_ssl(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void *data _U_)
         case TLSV1_VERSION:
         case TLSV1DOT1_VERSION:
         case TLSV1DOT2_VERSION:
+        case GMTLSV1_VERSION:
             /* SSLv3/TLS record headers need at least 1+2+2 = 5 bytes. */
             if (tvb_reported_length_remaining(tvb, offset) < 5) {
                 if (tls_desegment && pinfo->can_desegment) {
@@ -904,7 +905,8 @@ is_sslv3_or_tls(tvbuff_t *tvb)
     if (protocol_version != SSLV3_VERSION &&
         protocol_version != TLSV1_VERSION &&
         protocol_version != TLSV1DOT1_VERSION &&
-        protocol_version != TLSV1DOT2_VERSION) {
+        protocol_version != TLSV1DOT2_VERSION &&
+        protocol_version != GMTLSV1_VERSION ) {
         return FALSE;
     }
 
@@ -1778,7 +1780,8 @@ dissect_ssl3_record(tvbuff_t *tvb, packet_info *pinfo,
     /* TLS 1.0/1.1 just ignores unknown records - RFC 2246 chapter 6. The TLS Record Protocol */
     if ((session->version==TLSV1_VERSION ||
          session->version==TLSV1DOT1_VERSION ||
-         session->version==TLSV1DOT2_VERSION) &&
+         session->version==TLSV1DOT2_VERSION ||
+         session->version==GMTLSV1_VERSION ) &&
         (available_bytes >=1 ) && !ssl_is_valid_content_type(tvb_get_guint8(tvb, offset))) {
         proto_tree_add_expert(tree, pinfo, &ei_tls_ignored_unknown_record, tvb, offset, available_bytes);
         col_append_sep_str(pinfo->cinfo, COL_INFO, NULL, "Ignored Unknown Record");
@@ -3488,6 +3491,7 @@ void ssl_set_master_secret(guint32 frame_num, address *addr_srv, address *addr_c
         case TLSV1_VERSION:
         case TLSV1DOT1_VERSION:
         case TLSV1DOT2_VERSION:
+        case GMTLSV1_VERSION:
             ssl->session.version = version;
             ssl->state |= SSL_VERSION;
             ssl_debug_printf("%s set version 0x%04X -> state 0x%02X\n", G_STRFUNC, ssl->session.version, ssl->state);
@@ -3670,6 +3674,7 @@ ssl_looks_like_sslv3(tvbuff_t *tvb, const guint32 offset)
     case TLSV1_VERSION:
     case TLSV1DOT1_VERSION:
     case TLSV1DOT2_VERSION:
+    case GMTLSV1_VERSION:
         return 1;
     }
     return 0;


### PR DESCRIPTION
close #10, close #14 

1. fix incorrect order for newly added GM cipher suites

2. add another GitHub Action job to upload build assets to tag releases with "gm" postfix

@pengtianabc cr, please

